### PR TITLE
feat!: upgrade to Concerto v4.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "license": "ISC",
   "dependencies": {
     "@accordproject/concerto-cli": "^4.0.0",
-    "@accordproject/concerto-core": "^4.0.2",
-    "@accordproject/concerto-cto": "^4.0.2",
+    "@accordproject/concerto-core": "^4.0.3",
+    "@accordproject/concerto-cto": "^4.0.3",
     "child_process": "^1.0.2",
     "dotenv": "^17.0.1",
     "fs": "^0.0.1-security",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@accordproject/concerto-cli": "^3.19.0",
-    "@accordproject/concerto-core": "^3.26.0",
-    "@accordproject/concerto-cto": "^3.26.0",
+    "@accordproject/concerto-cli": "^4.0.0",
+    "@accordproject/concerto-core": "^4.0.2",
+    "@accordproject/concerto-cto": "^4.0.2",
     "child_process": "^1.0.2",
     "dotenv": "^17.0.1",
     "fs": "^0.0.1-security",

--- a/semantic/features/support/Javascript/world.ts
+++ b/semantic/features/support/Javascript/world.ts
@@ -12,7 +12,7 @@ export class CustomWorld {
   async initialize() {
     const deps = await loadDependencies();
     const ModelManager = deps.ModelManager;
-    this.modelManager = new ModelManager({ strict: true, importAliasing: true, enableMapType: true });
+    this.modelManager = new ModelManager({ importAliasing: true, enableMapType: true });
   }
 }
 

--- a/semantic/features/support/Javascript/world.ts
+++ b/semantic/features/support/Javascript/world.ts
@@ -12,7 +12,7 @@ export class CustomWorld {
   async initialize() {
     const deps = await loadDependencies();
     const ModelManager = deps.ModelManager;
-    this.modelManager = new ModelManager({ importAliasing: true, enableMapType: true });
+    this.modelManager = new ModelManager();
   }
 }
 


### PR DESCRIPTION
## Summary

- Bump `@accordproject/concerto-core` and `@accordproject/concerto-cto` to `^4.0.2`
- Bump `@accordproject/concerto-cli` to `^4.0.0`
- Remove deprecated `strict: true` from `ModelManager` constructor in `semantic/features/support/Javascript/world.ts` — strictness moved to `Serializer` in v4 per [migration guide](https://concerto.accordproject.org/docs/reference/migration/ref-migrate-concerto-3.0-4.0)

## Blocked by

- `concerto-cli` v4 must be published to npm before `npm install` resolves (code is on `main`, awaiting release)

## Related

- Part of [accordproject/concerto#1190](https://github.com/accordproject/concerto/issues/1190)
- Closes [#29](https://github.com/accordproject/concerto-conformance/issues/29)

## Test plan

- [x] `npm install` once `concerto-cli@4.0.0` is published
- [ ] `npm test` passes against Concerto v4

🤖 Generated with [Claude Code](https://claude.ai/claude-code)